### PR TITLE
Modernize examples and give them slightly better names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Rust library to ease the task of creating daemons, I have drawn heavy inspiration from [Daemonize by knsd](https://github.com/knsd/daemonize).
 
 # Current releases and EOL table
+
 | track    | version | EOL     |
 |----------|---------|---------|
 | 2.0      | 2.0.1   | TBA     |
@@ -13,7 +14,7 @@ Add it to your cargo.toml this will add the whole 2.0.x series as compatible as 
 ```toml
 daemonize-me = "2.0"
 ```
-Then look at [example.rs](examples/example.rs)
+Then look at [hooks.rs](examples/hooks.rs)
 
 
 ## OS support

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -1,11 +1,8 @@
-extern crate daemonize_me;
-
 use std::any::Any;
 use std::fs::File;
 use std::process::exit;
 
-pub use daemonize_me::Daemon;
-
+use daemonize_me::Daemon;
 
 fn post_fork_parent(ppid: i32, cpid: i32) -> ! {
     println!("Parent pid: {}, Child pid {}", ppid, cpid);
@@ -18,12 +15,12 @@ fn post_fork_child(ppid: i32, cpid: i32) {
     println!("Parent pid: {}, Child pid {}", ppid, cpid);
     println!("This hook is called in the child");
     // Child hook must return
-    return
+    return;
 }
 
 fn after_init(_: Option<&dyn Any>) {
     println!("Initialized the daemon!");
-    return
+    return;
 }
 
 fn main() {
@@ -47,7 +44,7 @@ fn main() {
         Err(e) => {
             eprintln!("Error, {}", e);
             exit(-1);
-        },
+        }
     }
 
     for i in 0..=10000 {

--- a/examples/lingering.rs
+++ b/examples/lingering.rs
@@ -1,8 +1,6 @@
-extern crate daemonize_me;
-
 use std::fs::File;
 
-pub use daemonize_me::{Daemon, User, Group};
+use daemonize_me::{Daemon, Group, User};
 
 fn main() {
     let stdout = File::create("info.log").unwrap();


### PR DESCRIPTION
There's no need to prefix examples with example- as they are already in the examples/ dir.